### PR TITLE
Remove leaflet

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 shiny
 maps
 tigris
-leaflet
 extrafont
 ReporteRs
 RColorBrewer


### PR DESCRIPTION
Shiny Apps should install leaflet in their global.R, since the CRAN leaflet package is too old to use with leaflet.extras, another package we often use with leaflet.

The correct leaflet can be installed from `devtools::install_github('rstudio/leaflet')`