### PR TITLE
[CIVP-16486] upgrade datascience-r to 2.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.1.0] - 2018-07-27
+
 ### Changed
+- Upgraded base image datascience-r from 2.3.0 -> 2.7.0
 - Migrate CircleCI build from v1.0 to v2.0
+
+## [1.0.4] - 2018-03-05
+
+### Added
+- A default shiny app present in app directory.
 
 ## [1.0.3] - 2018-02-08
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-r:2.3.0
+FROM civisanalytics/datascience-r:2.7.0
 
 RUN apt-get update && apt-get install -y \
     git


### PR DESCRIPTION
A client needs civis-r: v1.5.0 so we need to up the version of datascience-r to 2.7.0