### PR TITLE
[CIVP-17800] Update to 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [1.2.0] - 2019-02-13
+
+- Upgraded base image datascience-r from 2.7.0 -> 2.8.0
+
 ## [1.1.0] - 2018-07-27
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-r:2.7.0
+FROM civisanalytics/datascience-r:2.8.0
 
 RUN apt-get update && apt-get install -y \
     git

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you would like to test the image locally follow the steps below:
    ```
 3. Run the container:
    ```
-   docker run --rm -p 3838:3838 -v $(pwd)/shiny_example:/app -e APP_DIR=/app civis-services-shiny:test
+   docker run --rm -p 3838:3838 -e APP_DIR=/app civis-services-shiny:test
    ```
 
    This mounts the `shiny_example` folder in the Docker container under `/app`, where the entrypoint expects to find it.  You will need to modify the run command if your application is at a different path.
@@ -41,6 +41,8 @@ If you would like to test the image locally follow the steps below:
    ```
    <docker-host-ip>:3838
    ```
+
+For example, when using Docker for Mac `<docker-host-ip>` was `127.0.0.1`.
 
 # Contributing
 


### PR DESCRIPTION
This upgrades the shiny image to use the base image `datascience-r:2.8.0`. 

The base image updates e.g:
- `rocker/verse -> 3.5.2` 
- `R -> 3.5.2`
- `civis-r -> 1.6.1` (containing the upper case API fix)

Many packages included in the base image such as shiny, ggplot2, dplyr, etc will be updated as well.