### PR TITLE
[CIVP-18713] datascience-r 2.8.0 -> 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
+## [1.3.0] - 2019-06-21
+
+- Upgraded base image datascience-r from 2.8.0 -> 3.0.0
+
 ## [1.2.0] - 2019-02-13
 
 - Upgraded base image datascience-r from 2.7.0 -> 2.8.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM civisanalytics/datascience-r:2.8.0
+FROM civisanalytics/datascience-r:3.0.0
 
 RUN apt-get update && apt-get install -y \
     git


### PR DESCRIPTION
Upgraded base image datascience-r from 2.8.0 -> 3.0.0. 

I spun up the test app in the new image locally.


