### PR TITLE
[Hack-428] gis-packages Docker Image

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,7 +22,7 @@ reproduce the bug.
 ### Modify the Docker image
 
 If you know exactly what needs to change, you can also
-submit a pull request to propose the change.
+submit a pull request to propose the change. Make sure to make the same changes to the gis-packages.Dockerfile so the gis-packages image is updated as well.
 
 1. Fork it ( https://github.com/civisanalytics/civis-services-shiny/fork ).
 2. Make sure you are able to build the Docker image locally (`docker build -t civis-services-shiny:test .`)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,20 @@ will give you the most recently built version of the civis-services-shiny
 image. You can replace the tag `latest` with a version number such as `1.0`
 to retrieve a reproducible environment.
 
+## Custom Docker Image with common GIS packages
+We automatically upload this image with additional GIS packages to DockerHub. For the latest version of these you can
+
+Either build the Docker image locally
+```bash
+docker build -f gis-packages.Dockerfile -t civis-services-shiny .
+```
+
+or download the image from DockerHub
+```bash
+docker pull civisanalytics/civis-services-shiny:gis-packages
+```
+
+
 # Testing Integration with the Civis Platform
 
 If you would like to test the image locally follow the steps below:

--- a/gis-packages-requirements.txt
+++ b/gis-packages-requirements.txt
@@ -1,0 +1,8 @@
+shiny
+maps
+tigris
+leaflet
+extrafont
+ReporteRs
+RColorBrewer
+htmltools

--- a/gis-packages.Dockerfile
+++ b/gis-packages.Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update && apt-get install -y \
     apt-get update ; \
     apt-get install -y libgdal-dev
 
-COPY ./requirements.txt /requirements.txt
+COPY ./gis-packages-requirements.txt /gis-packages-requirements.txt
 RUN Rscript -e "packages <- readLines('/requirements.txt'); install.packages(packages)"
 
 COPY entrypoint.sh /

--- a/gis-packages.Dockerfile
+++ b/gis-packages.Dockerfile
@@ -1,0 +1,31 @@
+FROM civisanalytics/datascience-r:3.3.0
+
+RUN apt-get update && apt-get install -y \
+    git \
+    software-properties-common \
+    gnupg \
+    libudunits2-dev \
+    libgeos-dev \
+    libcairo-dev \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    libxml2-dev \
+    default-jre \
+    default-jdk \
+    gdebi-core \
+    wget \
+    pandoc \
+    pandoc-citeproc \
+    fonts-lato && \
+    add-apt-repository -y ppa:ubuntugis/ppa && \
+    apt-get update ; \
+    apt-get install -y libgdal-dev
+
+COPY ./requirements.txt /requirements.txt
+RUN Rscript -e "packages <- readLines('/requirements.txt'); install.packages(packages)"
+
+COPY entrypoint.sh /
+
+EXPOSE 3838
+
+ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
Right now we have a separate branch that is for the gis-packages Docker Image. We should store this in master so that the image is updated when there is a change.

**Manual tests**
Deployed a shiny app with this docker image made in the docker-scratch repo and it ran as expected without error